### PR TITLE
Acampos dockerizacao

### DIFF
--- a/MedSched/Dockerfile
+++ b/MedSched/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:21-jdk
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/MedSched/src/main/java/com/fiap/medsched/config/KafkaProducerConfig.java
+++ b/MedSched/src/main/java/com/fiap/medsched/config/KafkaProducerConfig.java
@@ -18,10 +18,15 @@ import java.util.Map;
 @EnableKafka
 public class KafkaProducerConfig {
 
+    // Faz usar o nome do serviço definido no docker-compose.yml e que 
+    // localhost:9092 só será usado em ambiente local fora do container.
+    @Value("${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}")
+    private String bootstrapServers;
+
     @Bean
     public Map<String, Object> producerConfigs() {
         Map<String, Object> props = new HashMap<>();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 10_000);

--- a/MedSched/src/main/java/com/fiap/medsched/config/KafkaProducerConfig.java
+++ b/MedSched/src/main/java/com/fiap/medsched/config/KafkaProducerConfig.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/Notifier/notifier-test-producer/src/main/java/com/medhub/notifier/configuration/KafkaProducerConfig.java
+++ b/Notifier/notifier-test-producer/src/main/java/com/medhub/notifier/configuration/KafkaProducerConfig.java
@@ -15,6 +15,7 @@ import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/Notifier/notifier-test-producer/src/main/java/com/medhub/notifier/configuration/KafkaProducerConfig.java
+++ b/Notifier/notifier-test-producer/src/main/java/com/medhub/notifier/configuration/KafkaProducerConfig.java
@@ -22,12 +22,15 @@ import java.util.Map;
 @Configuration
 @EnableKafka
 public class KafkaProducerConfig {
-    // Configs do producer:
+    // Faz usar o nome do serviço definido no docker-compose.yml e que 
+    // localhost:9092 só será usado em ambiente local fora do container.
+    @Value("${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}")
+    private String bootstrapServers;
 
     @Bean
     public Map<String, Object> producerConfigs() {
         Map<String, Object> props = new HashMap<>();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 10_000);
@@ -49,7 +52,7 @@ public class KafkaProducerConfig {
     @Bean
     public Map<String, Object> consumerConfigs() {
         Map<String, Object> props = new HashMap<>();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         // Para consumir todas as mensagens da fila, nao somente as mensagens criadas apos a criação do consumer
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/Notifier/notifier/Dockerfile
+++ b/Notifier/notifier/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.6-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY . .
+RUN mvn clean package -DskipTests
+
+FROM eclipse-temurin:21-jdk
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Notifier/notifier/src/main/java/com/medhub/notifier/configuration/KafkaConsumerConfig.java
+++ b/Notifier/notifier/src/main/java/com/medhub/notifier/configuration/KafkaConsumerConfig.java
@@ -23,12 +23,15 @@ import java.util.Map;
 @Configuration
 @EnableKafka
 public class KafkaConsumerConfig {
-    // Configs do producer:
+    // Faz usar o nome do serviço definido no docker-compose.yml e que 
+    // localhost:9092 só será usado em ambiente local fora do container.
+    @Value("${SPRING_KAFKA_BOOTSTRAP_SERVERS:localhost:9092}")
+    private String bootstrapServers;
 
     @Bean
     public Map<String, Object> producerConfigs() {
         Map<String, Object> props = new HashMap<>();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 10_000);
@@ -50,7 +53,7 @@ public class KafkaConsumerConfig {
     @Bean
     public Map<String, Object> consumerConfigs() {
         Map<String, Object> props = new HashMap<>();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         // Para consumir todas as mensagens da fila, nao somente as mensagens criadas apos a criação do consumer

--- a/Notifier/notifier/src/main/java/com/medhub/notifier/configuration/KafkaConsumerConfig.java
+++ b/Notifier/notifier/src/main/java/com/medhub/notifier/configuration/KafkaConsumerConfig.java
@@ -16,6 +16,7 @@ import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+version: '3.8'
+
+services:
+  kafka:
+    image: apache/kafka:latest
+    container_name: medhub-kafka
+    ports:
+      - "9092:9092"
+    command: >
+      bash -c "
+        /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties &
+        sleep 10 &&
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092
+          --create --if-not-exists
+          --topic schedule-notification
+          --partitions 1
+          --replication-factor 1 &&
+        wait
+      "
+    environment:
+      KAFKA_KRAFT_BROKER_ID: 1
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+
+  medsched:
+    build:
+      context: ./MedSched
+    container_name: medhub-medsched
+    depends_on:
+      - kafka
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      SPRING_MAIL_HOST: smtp.mailtrap.io
+      SPRING_MAIL_PORT: 2525
+      SPRING_MAIL_USERNAME: your_mailtrap_username
+      SPRING_MAIL_PASSWORD: your_mailtrap_password
+    ports:
+      - "8080:8080"
+
+  notifier:
+    build:
+      context: ./Notifier/notifier
+    container_name: medhub-notifier
+    depends_on:
+      - kafka
+    environment:
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      SPRING_MAIL_HOST: smtp.mailtrap.io
+      SPRING_MAIL_PORT: 2525
+      SPRING_MAIL_USERNAME: your_mailtrap_username
+      SPRING_MAIL_PASSWORD: your_mailtrap_password
+    ports:
+      - "8081:8081"
+
+networks:
+  default:
+    name: medhub-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,45 +1,41 @@
 version: '3.8'
 
 services:
-  kafka:
+  medhub-kafka:
     image: apache/kafka:latest
     container_name: medhub-kafka
+    hostname: medhub-kafka
     ports:
       - "9092:9092"
-    command: >
-      bash -c "
-        /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties &
-        sleep 10 &&
-        /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092
-          --create --if-not-exists
-          --topic schedule-notification
-          --partitions 1
-          --replication-factor 1 &&
-        wait
-      "
     environment:
-      KAFKA_KRAFT_BROKER_ID: 1
-      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://medhub-kafka:9092
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@medhub-kafka:9093
       KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+
+  kafka-init:
+    image: apache/kafka:latest
+    depends_on:
+      - medhub-kafka
+    entrypoint: ["/bin/sh", "-c"]
+    command: |
+      "
+      sleep 5 &&
+      /opt/kafka/bin/kafka-topics.sh --bootstrap-server medhub-kafka:9092 --create --if-not-exists --topic __consumer_offsets --partitions 50 --replication-factor 1 &&
+      /opt/kafka/bin/kafka-topics.sh --bootstrap-server medhub-kafka:9092 --create --if-not-exists --topic schedule-notification --partitions 1 --replication-factor 1
+      "
 
   medsched:
     build:
       context: ./MedSched
     container_name: medhub-medsched
     depends_on:
-      - kafka
+      - kafka-init
     environment:
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      SPRING_MAIL_HOST: smtp.mailtrap.io
-      SPRING_MAIL_PORT: 2525
-      SPRING_MAIL_USERNAME: your_mailtrap_username
-      SPRING_MAIL_PASSWORD: your_mailtrap_password
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: medhub-kafka:9092
     ports:
       - "8080:8080"
 
@@ -48,13 +44,9 @@ services:
       context: ./Notifier/notifier
     container_name: medhub-notifier
     depends_on:
-      - kafka
+      - kafka-init
     environment:
-      SPRING_KAFKA_BOOTSTRAP_SERVERS: kafka:9092
-      SPRING_MAIL_HOST: smtp.mailtrap.io
-      SPRING_MAIL_PORT: 2525
-      SPRING_MAIL_USERNAME: your_mailtrap_username
-      SPRING_MAIL_PASSWORD: your_mailtrap_password
+      SPRING_KAFKA_BOOTSTRAP_SERVERS: medhub-kafka:9092
     ports:
       - "8081:8081"
 


### PR DESCRIPTION
# Contexto
Este PR implementa a dockerização dos serviços MedSched, Notifier, e o Kafka (com topico).

- Cria dockerfiles para MedSched e Notifier;
- Cria docker-compose.yml para subir todos os seriviços;
- Atualiza Kafka consumer e producer configs do MedSched e Notifier para que os serviços se comuniquem usando o alias de rede/service name e nao localhost;
- Define o alias de rede/service name no docker-compose para nao ser hardcoded.

# Testes:

1. Subi os serviços usando `docker-compose up --build`.
2. Executei as requests para criação de paciente, medico e agendamento pelo postman.
3. Verifiquei os logs e email para confirmar a produção/consumo da mensagem no kafka.
4. Verifiquei o email para ver se realmente foi enviado.

## Screenshots:
![image](https://github.com/user-attachments/assets/20bec77b-ebdc-465e-b0da-e19d784d491c)
![image](https://github.com/user-attachments/assets/9a87525d-638f-4b0c-ab52-9ea634902d6d)
![image](https://github.com/user-attachments/assets/1e4861fc-bc6d-4546-9e5d-9707ef8a48e2)
![image](https://github.com/user-attachments/assets/1da7677f-bbc7-4804-92a6-d9dc41aa54c6)
![image](https://github.com/user-attachments/assets/7fbf6997-0baf-4549-b6d4-14ff78cbc3e6)
![image](https://github.com/user-attachments/assets/b5804036-b69f-4eb1-ad77-c4ce7be8df26)
![image](https://github.com/user-attachments/assets/6d5f2929-45de-4ad4-83cf-ae5416c7d9ba)

